### PR TITLE
feat: handling timedelta objects in the FriendlyEncoder class

### DIFF
--- a/essentials/json.py
+++ b/essentials/json.py
@@ -6,7 +6,7 @@ supporting time objects, UUID and bytes.
 import base64
 import dataclasses
 import json
-from datetime import date, datetime, time
+from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from enum import Enum
 from typing import Any
@@ -28,6 +28,8 @@ class FriendlyEncoder(json.JSONEncoder):
                 return obj.strftime("%H:%M:%S")
             if isinstance(obj, datetime):
                 return obj.isoformat()
+            if isinstance(obj, timedelta):
+                return obj.total_seconds()
             if isinstance(obj, date):
                 return obj.strftime("%Y-%m-%d")
             if isinstance(obj, bytes):


### PR DESCRIPTION
I came to an use case in Blacksheep where I needed to return timedelta objects. This timedelta object was inside a Pydantic BaseModel. But I got the error `TypeError: Object of type timedelta is not JSON serializable` because essentials didn't handle timedelta objects. Leaving this small contrib. Hope it helps others too.

Changes:
* Added another `if` statement, that checkes if `obj` is an instance of a `timedelta` object.